### PR TITLE
Add n-key-wallet example

### DIFF
--- a/smart-wallets/coin-contract/coin.pact
+++ b/smart-wallets/coin-contract/coin.pact
@@ -1,0 +1,498 @@
+(module coin GOVERNANCE
+
+  @doc "'coin' represents the Kadena Coin Contract. This contract provides both the \
+  \buy/redeem gas support in the form of 'fund-tx', as well as transfer,       \
+  \credit, debit, coinbase, account creation and query, as well as SPV burn    \
+  \create. To access the coin contract, you may use its fully-qualified name,  \
+  \or issue the '(use coin)' command in the body of a module declaration."
+
+  @model
+    [ (defproperty conserves-mass
+        (= (column-delta coin-table 'balance) 0.0))
+
+      (defproperty valid-account (account:string)
+        (and
+          (>= (length account) 3)
+          (<= (length account) 256)))
+    ]
+
+  (implements fungible-v2)
+
+  ; --------------------------------------------------------------------------
+  ; Schemas and Tables
+
+  (defschema coin-schema
+    @doc "The coin contract token schema"
+    @model [ (invariant (>= balance 0.0)) ]
+
+    balance:decimal
+    guard:guard)
+
+  (deftable coin-table:{coin-schema})
+
+  ; --------------------------------------------------------------------------
+  ; Capabilities
+
+  (defcap GOVERNANCE ()
+    (enforce false "Enforce non-upgradeability"))
+
+  (defcap GAS ()
+    "Magic capability to protect gas buy and redeem"
+    true)
+
+  (defcap COINBASE ()
+    "Magic capability to protect miner reward"
+    true)
+
+  (defcap GENESIS ()
+    "Magic capability constraining genesis transactions"
+    true)
+
+  (defcap REMEDIATE ()
+    "Magic capability for remediation transactions"
+    true)
+
+  (defcap DEBIT (sender:string)
+    "Capability for managing debiting operations"
+    (enforce-guard (at 'guard (read coin-table sender)))
+    (enforce (!= sender "") "valid sender"))
+
+  (defcap CREDIT (receiver:string)
+    "Capability for managing crediting operations"
+    (enforce (!= receiver "") "valid receiver"))
+
+  (defcap ROTATE (account:string)
+    @doc "Autonomously managed capability for guard rotation"
+    true)
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce (!= sender receiver) "same sender and receiver")
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Positive amount")
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver))
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Constants
+
+  (defconst COIN_CHARSET CHARSET_LATIN1
+    "The default coin contract character set")
+
+  (defconst MINIMUM_PRECISION 12
+    "Minimum allowed precision for coin transactions")
+
+  (defconst MINIMUM_ACCOUNT_LENGTH 3
+    "Minimum account length admissible for coin accounts")
+
+  (defconst MAXIMUM_ACCOUNT_LENGTH 256
+    "Maximum account name length admissible for coin accounts")
+
+  ; --------------------------------------------------------------------------
+  ; Utilities
+
+  (defun enforce-unit:bool (amount:decimal)
+    @doc "Enforce minimum precision allowed for coin transactions"
+
+    (enforce
+      (= (floor amount MINIMUM_PRECISION)
+         amount)
+      (format "Amount violates minimum precision: {}" [amount]))
+    )
+
+  (defun validate-account (account:string)
+    @doc "Enforce that an account name conforms to the coin contract \
+         \minimum and maximum length requirements, as well as the    \
+         \latin-1 character set."
+
+    (enforce
+      (is-charset COIN_CHARSET account)
+      (format
+        "Account does not conform to the coin contract charset: {}"
+        [account]))
+
+    (let ((account-length (length account)))
+
+      (enforce
+        (>= account-length MINIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the min length requirement: {}"
+          [account]))
+
+      (enforce
+        (<= account-length MAXIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the max length requirement: {}"
+          [account]))
+      )
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Coin Contract
+
+  (defun gas-only ()
+    "Predicate for gas-only user guards."
+    (require-capability (GAS)))
+
+  (defun gas-guard (guard:guard)
+    "Predicate for gas + single key user guards"
+    (enforce-one
+      "Enforce either the presence of a GAS cap or keyset"
+      [ (gas-only)
+        (enforce-guard guard)
+      ]))
+
+  (defun buy-gas:string (sender:string total:decimal)
+    @doc "This function describes the main 'gas buy' operation. At this point \
+    \MINER has been chosen from the pool, and will be validated. The SENDER   \
+    \of this transaction has specified a gas limit LIMIT (maximum gas) for    \
+    \the transaction, and the price is the spot price of gas at that time.    \
+    \The gas buy will be executed prior to executing SENDER's code."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+           ]
+
+    (validate-account sender)
+
+    (enforce-unit total)
+    (enforce (> total 0.0) "gas supply must be a positive quantity")
+
+    (require-capability (GAS))
+    (with-capability (DEBIT sender)
+      (debit sender total))
+    )
+
+  (defun redeem-gas:string (miner:string miner-guard:guard sender:string total:decimal)
+    @doc "This function describes the main 'redeem gas' operation. At this    \
+    \point, the SENDER's transaction has been executed, and the gas that      \
+    \was charged has been calculated. MINER will be credited the gas cost,    \
+    \and SENDER will receive the remainder up to the limit"
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+           ]
+
+    (validate-account sender)
+    (validate-account miner)
+    (enforce-unit total)
+
+    (require-capability (GAS))
+    (let*
+      ((fee (read-decimal "fee"))
+       (refund (- total fee)))
+
+      (enforce-unit fee)
+      (enforce (>= fee 0.0)
+        "fee must be a non-negative quantity")
+
+      (enforce (>= refund 0.0)
+        "refund must be a non-negative quantity")
+
+        ; directly update instead of credit
+      (with-capability (CREDIT sender)
+        (if (> refund 0.0)
+          (with-read coin-table sender
+            { "balance" := balance }
+            (update coin-table sender
+              { "balance": (+ balance refund) }))
+
+          "noop"))
+
+      (with-capability (CREDIT miner)
+        (if (> fee 0.0)
+          (credit miner miner-guard fee)
+          "noop"))
+      )
+
+    )
+
+  (defun create-account:string (account:string guard:guard)
+    @model [ (property (valid-account account)) ]
+
+    (validate-account account)
+
+    (insert coin-table account
+      { "balance" : 0.0
+      , "guard"   : guard
+      })
+    )
+
+  (defun get-balance:decimal (account:string)
+    (with-read coin-table account
+      { "balance" := balance }
+      balance
+      )
+    )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account:string )
+    (with-read coin-table account
+      { "balance" := bal
+      , "guard" := g }
+      { "account" : account
+      , "balance" : bal
+      , "guard": g })
+    )
+
+  (defun rotate:string (account:string new-guard:guard)
+    (with-capability (ROTATE account)
+      (with-read coin-table account
+        { "guard" := old-guard }
+
+        (enforce-guard old-guard)
+
+        (update coin-table account
+          { "guard" : new-guard }
+          )))
+    )
+
+
+  (defun precision:integer
+    ()
+    MINIMUM_PRECISION)
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+    @model [ (property conserves-mass)
+             (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+             (property (!= sender receiver)) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read coin-table receiver
+        { "guard" := g }
+
+        (credit receiver g amount))
+      )
+    )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+
+    @model [ (property conserves-mass) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount))
+    )
+
+  (defun coinbase:string (account:string account-guard:guard amount:decimal)
+    @doc "Internal function for the initial creation of coins.  This function \
+    \cannot be used outside of the coin contract."
+
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+    (enforce-unit amount)
+
+    (require-capability (COINBASE))
+    (with-capability (CREDIT account)
+      (credit account account-guard amount))
+    )
+
+  (defun remediate:string (account:string amount:decimal)
+    @doc "Allows for remediation transactions. This function \
+         \is protected by the REMEDIATE capability"
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "Remediation amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (REMEDIATE))
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+  (defpact fund-tx (sender:string miner:string miner-guard:guard total:decimal)
+    @doc "'fund-tx' is a special pact to fund a transaction in two steps,     \
+    \with the actual transaction transpiring in the middle:                   \
+    \                                                                         \
+    \  1) A buying phase, debiting the sender for total gas and fee, yielding \
+    \     TX_MAX_CHARGE.                                                      \
+    \  2) A settlement phase, resuming TX_MAX_CHARGE, and allocating to the   \
+    \     coinbase account for used gas and fee, and sender account for bal-  \
+    \     ance (unused gas, if any)."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+             ;(property conserves-mass) not supported yet
+           ]
+
+    (step (buy-gas sender total))
+    (step (redeem-gas miner miner-guard sender total))
+    )
+
+  (defun debit:string (account:string amount:decimal)
+    @doc "Debit AMOUNT from ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "debit amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (DEBIT account))
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+
+  (defun credit:string (account:string guard:guard amount:decimal)
+    @doc "Credit AMOUNT to ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0) "credit amount must be positive")
+    (enforce-unit amount)
+
+    (require-capability (CREDIT account))
+    (with-default-read coin-table account
+      { "balance" : 0.0, "guard" : guard }
+      { "balance" := balance, "guard" := retg }
+      ; we don't want to overwrite an existing guard with the user-supplied one
+      (enforce (= retg guard)
+        "account guards do not match")
+
+      (write coin-table account
+        { "balance" : (+ balance amount)
+        , "guard"   : retg
+        })
+      ))
+
+
+  (defschema crosschain-schema
+    @doc "Schema for yielded value in cross-chain transfers"
+    receiver:string
+    receiver-guard:guard
+    amount:decimal)
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+           ]
+
+    (step
+      (with-capability (DEBIT sender)
+
+        (validate-account sender)
+        (validate-account receiver)
+
+        (enforce (!= "" target-chain) "empty target-chain")
+        (enforce (!= (at 'chain-id (chain-data)) target-chain)
+          "cannot run cross-chain transfers to the same chain")
+
+        (enforce (> amount 0.0)
+          "transfer quantity must be positive")
+
+        (enforce-unit amount)
+
+        ;; step 1 - debit delete-account on current chain
+        (debit sender amount)
+
+        (let
+          ((crosschain-details:object{crosschain-schema}
+            { "receiver" : receiver
+            , "receiver-guard" : receiver-guard
+            , "amount" : amount
+            }))
+          (yield crosschain-details target-chain)
+          )))
+
+    (step
+      (resume
+        { "receiver" := receiver
+        , "receiver-guard" := receiver-guard
+        , "amount" := amount
+        }
+
+        ;; step 2 - credit create account on target chain
+        (with-capability (CREDIT receiver)
+          (credit receiver receiver-guard amount))
+        ))
+    )
+
+
+)
+
+(create-table coin-table)

--- a/smart-wallets/coin-contract/fungible-v2.pact
+++ b/smart-wallets/coin-contract/fungible-v2.pact
@@ -1,0 +1,135 @@
+(interface fungible-v2
+
+  " Standard for fungible coins and tokens as specified in KIP-0002. "
+
+   ; ----------------------------------------------------------------------
+   ; Schema
+
+   (defschema account-details
+    @doc "Schema for results of 'account' operation."
+    @model [ (invariant (!= "" sender)) ]
+
+    account:string
+    balance:decimal
+    guard:guard)
+
+
+   ; ----------------------------------------------------------------------
+   ; Caps
+
+   (defcap TRANSFER:bool
+     ( sender:string
+       receiver:string
+       amount:decimal
+     )
+     @doc " Managed capability sealing AMOUNT for transfer from SENDER to \
+          \ RECEIVER. Permits any number of transfers up to AMOUNT."
+     @managed amount TRANSFER-mgr
+     )
+
+   (defun TRANSFER-mgr:decimal
+     ( managed:decimal
+       requested:decimal
+     )
+     @doc " Manages TRANSFER AMOUNT linearly, \
+          \ such that a request for 1.0 amount on a 3.0 \
+          \ managed quantity emits updated amount 2.0."
+     )
+
+   ; ----------------------------------------------------------------------
+   ; Functionality
+
+
+  (defun transfer:string
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+         \ Fails if either SENDER or RECEIVER does not exist."
+    @model [ (property (> amount 0.0))
+             (property (!= sender ""))
+             (property (!= receiver ""))
+             (property (!= sender receiver))
+           ]
+    )
+
+   (defun transfer-create:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       amount:decimal
+     )
+     @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+          \ Fails if SENDER does not exist. If RECEIVER exists, guard \
+          \ must match existing value. If RECEIVER does not exist, \
+          \ RECEIVER account is created using RECEIVER-GUARD. \
+          \ Subject to management by TRANSFER capability."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+            ]
+     )
+
+   (defpact transfer-crosschain:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       target-chain:string
+       amount:decimal
+     )
+     @doc " 2-step pact to transfer AMOUNT from SENDER on current chain \
+          \ to RECEIVER on TARGET-CHAIN via SPV proof. \
+          \ TARGET-CHAIN must be different than current chain id. \
+          \ First step debits AMOUNT coins in SENDER account and yields \
+          \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
+          \ Second step continuation is sent into TARGET-CHAIN with proof \
+          \ obtained from the spv 'output' endpoint of Chainweb. \
+          \ Proof is validated and RECEIVER is credited with AMOUNT \
+          \ creating account with RECEIVER_GUARD as necessary."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+              (property (!= target-chain ""))
+            ]
+     )
+
+   (defun get-balance:decimal
+     ( account:string )
+     " Get balance for ACCOUNT. Fails if account does not exist."
+     )
+
+   (defun details:object{account-details}
+     ( account: string )
+     " Get an object with details of ACCOUNT. \
+     \ Fails if account does not exist."
+     )
+
+   (defun precision:integer
+     ()
+     "Return the maximum allowed decimal precision."
+     )
+
+   (defun enforce-unit:bool
+     ( amount:decimal )
+     " Enforce minimum precision allowed for transactions."
+     )
+
+   (defun create-account:string
+     ( account:string
+       guard:guard
+     )
+     " Create ACCOUNT with 0.0 balance, with GUARD controlling access."
+     )
+
+   (defun rotate:string
+     ( account:string
+       new-guard:guard
+     )
+     " Rotate guard for ACCOUNT. Transaction is validated against \
+     \ existing guard before installing new guard. "
+     )
+
+)

--- a/smart-wallets/n-key-wallet/n-key-wallet.pact
+++ b/smart-wallets/n-key-wallet/n-key-wallet.pact
@@ -1,0 +1,106 @@
+(define-keyset 'admin-keyset (read-keyset 'admin-keyset))
+
+(module n-key-wallet 'admin-keyset
+  @doc"'n-key-wallet' provides safe transactions of Kadena coins.                \
+  \ The accounts in the wallet are guarded by a list of keys and a guardian key. \
+  \ Each transfer will require n number of keys to be signed depending on the    \
+  \ ratio of (amount to transfer) : (total balance). For example, if an account  \
+  \ has a balance of 10.0 coins and guard list with 2 keys, then the transfer    \
+  \ of 0-5 coins will require 1 key to be signed, and the transfer of 5-10 coins \
+  \ will require 2 keys to be signed. Guardian key will allow the rotation of    \
+  \ guard list in case some keys are lost."
+
+  (defschema user
+    user:string
+    guards:list
+    guardian:guard)
+
+  (deftable user-table:{user})
+
+  (defun smart-guard:bool ()
+    @doc "Module guard"
+    (create-module-guard 'wallet-guard)
+    )
+
+  (defun create-smart-user (user:string guards:[guard] guardian:guard)
+    @doc "Create a coin account managed by customized smart wallet"
+    (enforce-guard guardian)
+    (insert user-table user {
+      "user": user,
+      "guards": guards,
+      "guardian": guardian
+      })
+    (coin.create-account user (smart-guard))
+  )
+
+  (defun smart-transfer (account receiver amount)
+    @doc "Runs coin.transfer with customized rules."
+    (enforce-signed account amount)
+    (coin.transfer account receiver amount))
+
+  (defun rotate-guards (user:string guards:[guard])
+    @doc "Rotate guards of the user"
+    (enforce-guardian user)
+    (update user-table user {
+      "guards": guards
+      }))
+
+  (defun rotate-guardian-guard (user:string guardian:guard)
+    @doc "Rotate guards of the user"
+    (enforce-guardian user)
+    (update user-table user {
+      "guardian": guardian
+      }))
+
+ ;;Utility functions
+ (defun enforce-guardian:bool (user:string)
+  @doc "Enforced the guardian guard"
+   (enforce-guard (guardian user))
+ )
+
+ (defun enforce-signed:bool (user amount)
+   @doc "Enforced customized rule to find what guards need to be signed."
+   (let* (
+     (needed (numKeysNeeded user amount))
+     (signed (numKeysSigned user)))
+     (enforce (<= needed signed)
+       (format "{} more keys need to be signed"
+       [(- needed signed)]))))
+
+  (defun numKeysNeeded:integer (user:string amount:decimal)
+    @doc "Number of keys required to transfer amount"
+    (let ((
+      balance (total-balance user)
+      ))
+    (enforce (<= amount balance) "Insufficient balance")
+    (logic (numKeys user) amount balance)))
+
+  (defun numKeysSigned:integer (user:string)
+    @doc "Number of keys signed"
+    (length
+      (filter
+        (= true)
+          (map (try-enforce-guard) (guards user)))))
+
+  (defun try-enforce-guard:bool (guard:guard)
+    @doc "Try enforcing a guard for transfer and returns result"
+    (try false (enforce-guard guard)))
+
+  (defun logic:integer (numKeys:integer amount:decimal total:decimal)
+    @doc "Default logic to calculate number of keys needed to transfer amount"
+    (ceiling (* numKeys (/ amount total))))
+
+  (defun numKeys (user:string)
+    (length (guards user)))
+
+  (defun guards (user:string)
+    (at 'guards (read user-table user)))
+
+  (defun guardian (user:string)
+    (at 'guardian (read user-table user)))
+
+  (defun total-balance (user:string)
+    (at 'balance (coin.details user)))
+)
+
+(create-table user-table)

--- a/smart-wallets/n-key-wallet/n-key-wallet.repl
+++ b/smart-wallets/n-key-wallet/n-key-wallet.repl
@@ -1,0 +1,241 @@
+;;Load contracts
+(begin-tx)
+(env-data {
+  "admin-keyset": ["wallet-admin"]
+  })
+(env-keys ["wallet-admin"])
+(load "../coin-contract/fungible-v2.pact")
+(load "../coin-contract/coin.pact")
+
+;;Load admin key
+(env-data {
+  "admin-keyset": ["wallet-admin"]
+  })
+
+(load "n-key-wallet.pact")
+(commit-tx)
+
+(begin-tx)
+;;Load Account keysets
+(env-data
+  {"acct1": {
+        "keys": [
+            "acct1-key"
+        ],
+        "pred": "keys-all"
+    },
+  "acct2": {
+          "keys": [
+              "acct2-key"
+          ],
+          "pred": "keys-all"
+      },
+  "new": {
+    "keys": [
+        "new-key"
+    ],
+    "pred": "keys-all"
+    },
+    "guardian-guard": {
+      "keys": [
+          "guardian-key"
+      ],
+      "pred": "keys-all"
+      }
+      })
+
+(use n-key-wallet)
+
+;;Create wallet account, acct1
+(env-keys ["guardian-key"])
+(expect "acct1 is created as a smart user" "Write succeeded"
+  (create-smart-user "acct1" [(read-keyset 'acct1) (read-keyset 'acct2)] (read-keyset 'guardian-guard)))
+(expect "acct1 exists in coin table"
+  {"account": "acct1", "balance": 0.0, "guard": (smart-guard)}
+  (coin.details 'acct1))
+
+;;Fund acct1
+(test-capability (coin.COINBASE))
+(expect "acct1 is funded using coinbase" "Write succeeded"(coin.coinbase "acct1" (smart-guard) 100.0))
+(expect "acct1 balance is 100.0" 100.0
+  (at 'balance (coin.details 'acct1)))
+
+;;Test utility functions
+(commit-tx)
+;;logic
+(use n-key-wallet)
+(expect "50 / 100 when 6 keys are in the db" 3 (logic 6 50.0 100.0))
+(expect "51 / 100 when 6 keys are in the db" 4 (logic 6 51.0 100.0))
+(expect "51 / 100 when 2 keys are in the db" 2 (logic 2 51.0 100.0))
+(expect "1 / 100 when 2 keys are in the db" 1 (logic 2 1.0 100.0))
+
+;;numKeys Needed of acct1 to sign
+(expect "acct1 to sign transfer of 51.0" 2 (numKeysNeeded "acct1" 51.0))
+(expect "acct1 to sign transfer of 1.0" 1 (numKeysNeeded "acct1" 1.0))
+
+;;numKeys signed
+(env-keys [])
+(expect "0 keys are signed" 0 (numKeysSigned "acct1"))
+
+(env-keys ["acct1-key", "noone's-key"])
+(expect "1 keys are signed" 1 (numKeysSigned "acct1"))
+
+(env-keys ["acct2-key", "noone's-key"])
+(expect "1 keys are signed" 1 (numKeysSigned "acct1"))
+
+(env-keys ["acct1-key", "acct2-key", "noone's-key"])
+(expect "2 keys are signed" 2 (numKeysSigned "acct1"))
+
+;;Test smart transfer
+
+;;create a none-smart wallet user
+(begin-tx)
+(coin.create-account "acct2" (read-keyset 'new))
+(commit-tx)
+
+;;Test coin.transfer (will fail unless admin-key is signed)
+(begin-tx)
+(use n-key-wallet)
+
+(env-sigs [
+  ;;Bring TRANSFER capability into scope
+  {'key: "dumb-key", 'caps: [(coin.TRANSFER "acct1" "acct2" 100.0)]},
+  {"key": "acct1-key", "caps": []},
+  {"key": "acct2-key", "caps": []} ])
+
+(expect-failure
+  "coin.transfer does not succeed unless admin-keyset is signed"
+  "Keyset failure"
+  (coin.transfer 'acct1 'acct2 1.0))
+
+(env-sigs [
+  ;;Bring TRANSFER capability into scope
+  {'key: "wallet-admin", 'caps: [(coin.TRANSFER "acct1" "acct2" 100.0)]},
+  {"key": "acct1-key", "caps": []},
+  {"key": "acct2-key", "caps": []} ])
+
+(expect
+  "Transfer succeeds when admin-keyset(module guard) is signed"
+  "Write succeeded"
+  (coin.transfer 'acct1 'acct2 1.0))
+
+
+(rollback-tx)
+
+
+;;Test smart-transfer
+;;Sign with 1/2 key
+(begin-tx)
+(use n-key-wallet)
+
+(env-sigs [
+  ;;Bring TRANSFER capability into scope
+  {'key: "dumb-key", 'caps: [(coin.TRANSFER "acct1" "acct2" 100.0)]},
+  {"key": "acct1-key", "caps": []} ])
+
+(expect
+  "1/2 keys is signed for 1.0"
+  "Write succeeded" (smart-transfer 'acct1 'acct2 1.0))
+(expect "balance of acct1" 99.0 (total-balance 'acct1))
+(expect "balance of acct2" 1.0 (total-balance 'acct2))
+
+(expect-failure
+  "1/2 keys is signed for 51.0/99.0"
+  "1 more keys need to be signed"
+  (smart-transfer 'acct1 'acct2 51.0))
+(expect "balance of acct1" 99.0 (total-balance 'acct1))
+(expect "balance of acct2" 1.0 (total-balance 'acct2))
+(rollback-tx)
+
+;;Sign with 2/2 keys
+(begin-tx)
+(use n-key-wallet)
+
+(env-sigs [
+  ;;Bring TRANSFER capability into scope
+  {'key: "dumb-key", 'caps: [(coin.TRANSFER "acct1" "acct2" 100.0)]},
+  {"key": "acct1-key", "caps": []},
+  {"key": "acct2-key", "caps": []} ])
+
+(expect
+  "2/2 keys is signed for 1.0/100.0"
+  "Write succeeded" (smart-transfer 'acct1 'acct2 1.0))
+(expect "balance of acct1" 99.0 (total-balance 'acct1))
+(expect "balance of acct2" 1.0 (total-balance 'acct2))
+
+(expect
+  "2/2 keys is signed for 51.0/99.0"
+  "Write succeeded" (smart-transfer 'acct1 'acct2 51.0))
+(expect "balance of acct1" 48.0 (total-balance 'acct1))
+(expect "balance of acct2" 52.0 (total-balance 'acct2))
+
+(rollback-tx)
+
+(begin-tx)
+(use n-key-wallet)
+
+(env-data {
+  "new1-keyset": ["n1-key"],
+  "new2-keyset": ["n2-key"]
+  })
+
+;;Rotate guards
+
+;;Don't sign with guardian key
+(env-keys ['acct1-key 'acct2-key])
+
+(expect-failure
+  "Guardian is not signed"
+  "Keyset failure"
+  (rotate-guards "acct1" [
+    (read-keyset "new1-keyset")
+    (read-keyset "new2-keyset")]))
+
+;;Sign with guardian key
+(env-keys ['guardian-key])
+(expect
+  "Rotate guards of acct1"
+  "Write succeeded"
+  (rotate-guards "acct1" [
+    (read-keyset "new1-keyset")
+    (read-keyset "new2-keyset")]))
+(commit-tx)
+
+;;Transfer with old guards - will fail
+(begin-tx)
+(use n-key-wallet)
+
+(env-sigs [
+  ;;Bring TRANSFER capability into scope
+  {'key: "dumb-key", 'caps: [(coin.TRANSFER "acct1" "acct2" 100.0)]},
+  {"key": "acct1-key", "caps": []},
+  {"key": "acct2-key", "caps": []} ])
+
+(expect-failure
+  "Rotated keys are not signed"
+  "2 more keys need to be signed"
+  (smart-transfer 'acct1 'acct2 99.0))
+
+(expect "balance of acct1" 100.0 (total-balance 'acct1))
+(expect "balance of acct2" 0.0 (total-balance 'acct2))
+
+(commit-tx)
+
+;;Transfer with rotated guards - will fail
+(begin-tx)
+(use n-key-wallet)
+
+(env-sigs [
+  ;;Bring TRANSFER capability into scope
+  {'key: "dumb-key", 'caps: [(coin.TRANSFER "acct1" "acct2" 100.0)]},
+  {"key": "n1-key", "caps": []},
+  {"key": "n2-key", "caps": []} ])
+
+(expect
+  "2/2 of rotated keys is signed for 99.0/100.0"
+  "Write succeeded" (smart-transfer 'acct1 'acct2 99.0))
+
+(expect "balance of acct1" 1.0 (total-balance 'acct1))
+(expect "balance of acct2" 99.0 (total-balance 'acct2))
+
+(commit-tx)


### PR DESCRIPTION
- Smart wallet with a guard list and a guardian guard, which determines the number of keys that need to be signed by amount at transfer. 